### PR TITLE
Adding the option to run php without an ini

### DIFF
--- a/lib/php-cs-fixer.coffee
+++ b/lib/php-cs-fixer.coffee
@@ -37,6 +37,11 @@ module.exports = PhpCsFixer =
       type: 'boolean'
       default: false
       description: 'show some status informations from the last "fix"'
+    runPhpWithoutAnyIni:
+      title: 'Run php with the -n flag'
+      type: 'boolean'
+      default: false
+      description: 'Runs php without any ini configuration, useful for avoiding xdebug errors'
 
   activate: (state) ->
     atom.config.observe 'php-cs-fixer.executeOnSave', =>
@@ -56,6 +61,9 @@ module.exports = PhpCsFixer =
 
     atom.config.observe 'php-cs-fixer.showInfoNotifications', =>
       @showInfoNotifications = atom.config.get 'php-cs-fixer.showInfoNotifications'
+
+    atom.config.observe 'php-cs-fixer.runPhpWithoutAnyIni', =>
+      @runPhpWithoutAnyIni = atom.config.get 'php-cs-fixer.runPhpWithoutAnyIni'
 
     # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     @subscriptions = new CompositeDisposable
@@ -79,8 +87,13 @@ module.exports = PhpCsFixer =
 
     command = @phpExecutablePath
 
+    console.debug('php-cs-fixer Running with no INI?', @runPhpWithoutAnyIni);
+
     # init options
-    args = [@executablePath, 'fix', filePath]
+    if @runPhpWithoutAnyIni
+        args = ['-n', @executablePath, 'fix', filePath]
+    else
+        args = [@executablePath, 'fix', filePath]
 
     if configPath = @findFile(path.dirname(filePath), '.php_cs')
       args.push '--config-file=' + configPath


### PR DESCRIPTION
Hey,

Found this package very useful but I often need to have xdebug running to generate things like coverage reports for phpunit and found it annoying to get two messages popping up. This also offers a slight performance improvement as well because it's not actually running xdebug.
