### PR TITLE
Updated Composer Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The package requires the "[PHP Coding Standards Fixer](http://cs.sensiolabs.org)
 Installation via Composer
 
 ```bash
-$ ./composer.phar global require fabpot/php-cs-fixer
+$ ./composer.phar global require friendsofphp/php-cs-fixer
 ```
 
 For other installation methods, see <http://cs.sensiolabs.org/#installation>
@@ -93,4 +93,4 @@ I had to add a new settings-parameter "*PHP executable Path*" to get the plugin 
 
 ### On Windows this add-on does not work while running manually from the command line works
 
-You probably have to add the directory of the php.exe to the ```PATH``` environment variable. You can do this in the system properties. You should configure the php-cs-fixer executable path to point to the vendor directory (e.g. ```C:/Users/{username}/AppData/Roaming/Composer/vendor/fabpot/php-cs-fixer/php-cs-fixer```). For detailed information use the [Java guide](https://www.java.com/en/download/help/path.xml) or [this stackexchange answer](https://superuser.com/questions/284342/what-are-path-and-other-environment-variables-and-how-can-i-set-or-use-them).
+You probably have to add the directory of the php.exe to the ```PATH``` environment variable. You can do this in the system properties. You should configure the php-cs-fixer executable path to point to the vendor directory (e.g. ```C:/Users/{username}/AppData/Roaming/Composer/friendsofphp/php-cs-fixer/php-cs-fixer```). For detailed information use the [Java guide](https://www.java.com/en/download/help/path.xml) or [this stackexchange answer](https://superuser.com/questions/284342/what-are-path-and-other-environment-variables-and-how-can-i-set-or-use-them).


### PR DESCRIPTION
The current composer installation references "fabpot/php-cs-fixer" as this project has been abandoned and moved to "friendsofphp/php-cs-fixer", the README has been changed to reflect this.
