### PR TITLE
Add parameters to include Phar and Tokenizer modules needed form php-cs-fixer command

### DIFF
--- a/lib/php-cs-fixer.coffee
+++ b/lib/php-cs-fixer.coffee
@@ -91,7 +91,7 @@ module.exports = PhpCsFixer =
 
     # init options
     if @runPhpWithoutAnyIni
-        args = ['-n', @executablePath, 'fix', filePath]
+        args = ['-n', '-dextension=phar.so', '-dextension=tokenizer.so', @executablePath, 'fix', filePath]
     else
         args = [@executablePath, 'fix', filePath]
 


### PR DESCRIPTION
This fix a problem when you use the "Run php with the -n flag", php-cs-fixer needs this modules to run properly and php doesn't load them when running with the -n flag.

Below I put the messages thrown by php-cs-fixer when running without the new parameters and the result when you use both of them.

This fix probably doesn't work on Windows cause if I'm not wrong, they use DLLs instead of SO files (I'm using Linux) but I can't create a solution in that case since I don't have a Windows machines at the moment.

But at least, it would fix the problem in, probably, 2 operating systems (Linux and OS X).

Greets.

php-cs-fixer Running with no INI? true
php-cs-fixer.coffee:106 php-cs-fixer Command php
php-cs-fixer.coffee:107 php-cs-fixer Arguments ["-n", "/home/edomato/bin/php-cs-fixer", "fix", "/home/edomato/test.php", "--level=symfony"]
php-cs-fixer.coffee:117 
Fatal error: Uncaught Error: Class 'Phar' not found in /home/edomato/bin/php-cs-fixer:29
Stack trace:
#0 {main}

  thrown in /home/edomato/bin/php-cs-fixer on line 29

php-cs-fixer.coffee:123 php exited with code: 255

php-cs-fixer Running with no INI? true
php-cs-fixer.coffee:106 php-cs-fixer Command php
php-cs-fixer.coffee:107 php-cs-fixer Arguments ["-n", "-dextension=phar.so", "/home/edomato/bin/php-cs-fixer", "fix", "/home/edomato/test.php", "--level=symfony"]
php-cs-fixer.coffee:117 
Fatal error: Uncaught ErrorException: Use of undefined constant T_HALT_COMPILER - assumed 'T_HALT_COMPILER' in phar:///home/edomato/bin/php-cs-fixer/Symfony/CS/Fixer.php:78
Stack trace:
#0 phar:///home/edomato/bin/php-cs-fixer/Symfony/CS/Fixer.php(78): {closure}(8, 'Use of undefine...', 'phar:///home/ed...', 78, Array)
#1 phar:///home/edomato/bin/php-cs-fixer/Symfony/CS/Console/Command/FixCommand.php(93): Symfony\CS\Fixer->registerBuiltInFixers()
#2 phar:///home/edomato/bin/php-cs-fixer/Symfony/CS/Console/Application.php(35): Symfony\CS\Console\Command\FixCommand->__construct()
#3 /home/edomato/bin/php-cs-fixer(35): Symfony\CS\Console\Application->__construct()
#4 {main}

  thrown in phar:///home/edomato/bin/php-cs-fixer/Symfony/CS/Fixer.php on line 78

php-cs-fixer.coffee:123 php exited with code: 255

php-cs-fixer Running with no INI? true
php-cs-fixer.coffee:106 php-cs-fixer Command php
php-cs-fixer.coffee:107 php-cs-fixer Arguments ["-n", "-dextension=phar.so", "-dextension=tokenizer.so", "/home/edomato/bin/php-cs-fixer", "fix", "/home/edomato/test.php", "--level=symfony"]
php-cs-fixer.coffee:117 Fixed all files in 0.041 seconds, 6.000 MB memory used

php-cs-fixer.coffee:123 php exited with code: 0
