### PR TITLE
Parse @phpArguments as array or string when setted

### DIFF
--- a/lib/php-cs-fixer.coffee
+++ b/lib/php-cs-fixer.coffee
@@ -89,8 +89,11 @@ module.exports = PhpCsFixer =
 
     args = []
 
-    if @phpArguments
-      args = @phpArguments
+    if @phpArguments.length
+      if @phpArguments.length > 1
+        args = @phpArguments
+      else
+        args = @phpArguments[0].split(' ')
 
     args = args.concat [@executablePath, 'fix', filePath]
 


### PR DESCRIPTION
Ok, I fixed an issue of the new phpArguments parameter since in "Settings", is hard (to impossible) to distinguish between an array or a string parameter.

So, the first time that I tried the new option, it failed because I use "-n -dextension=..." as parameter and since that option is declared as an array, the concatenation to run the PHP command failed. Then I tried using comma separator (like "-n, -dextension=...") and it worked.

So, this pull request works without matter what syntax you use. The only restriction is that you can combine the syntax (like "-n, -dextension=x -dextension=y").

Greets
