### PR TITLE
Fix when the text editor is not in focus

### DIFF
--- a/lib/php-cs-fixer.coffee
+++ b/lib/php-cs-fixer.coffee
@@ -115,7 +115,7 @@ module.exports = PhpCsFixer =
     @subscriptions.dispose()
 
   fix: ->
-    editor = atom.workspace.getActivePaneItem()
+    editor = atom.workspace.getActiveTextEditor()
 
     filePath = editor.getPath() if editor && editor.getPath
 


### PR DESCRIPTION
Atom alert from deprecation when the focus is any pane except text editor cuz the file path is undefined.

before this fix:
If u wanna reproduce this error open a php file put the focus in the tree view and run the fix command.

after:
we always get the text editor active