### PR TITLE
Add support for PHP-CS-Fixer v3.x

### DIFF
--- a/examples/.php-cs-fixer.php
+++ b/examples/.php-cs-fixer.php
@@ -6,22 +6,22 @@ This file is part of PHP CS Fixer.
 This source file is subject to the MIT license that is bundled
 with this source code in the file LICENSE.
 EOF;
-return PhpCsFixer\Config::create()
-    ->setRiskyAllowed(true)
+$config = new PhpCsFixer\Config();
+return $config->setRiskyAllowed(true)
     ->setRules(array(
         '@Symfony' => true,
         '@Symfony:risky' => true,
         'combine_consecutive_unsets' => true,
-        'header_comment' => array('header' => $header),
-        'array_syntax' => array('syntax' => 'long'),
-        'no_extra_consecutive_blank_lines' => array('break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block'),
+        'header_comment' => ['header' => $header],
+        'array_syntax' => ['syntax' => 'long'],
+        'no_extra_blank_lines' => ['tokens' => ['break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block']],
         'no_useless_else' => true,
         'no_useless_return' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,
         'php_unit_strict' => true,
         'phpdoc_add_missing_param_annotation' => true,
-        'psr4' => true,
+        'psr_autoloading' => true,
         'strict_comparison' => true,
         'strict_param' => true,
     ))

--- a/lib/php-cs-fixer.coffee
+++ b/lib/php-cs-fixer.coffee
@@ -53,13 +53,13 @@ module.exports = PhpCsFixer =
       title: 'PHP-CS-fixer config file path'
       type: 'string'
       default: ''
-      description: 'Optionally provide the path to the `.php_cs` config file, if the path is not provided it will be loaded from the root path of the current project.'
+      description: 'Optionally provide the path to the `.php_cs` or `.php-cs-fixer.php` config file, if the path is not provided it will be loaded from the root path of the current project.'
       order: 25
     requireConfig:
       title: 'Require a PHP-CS-fixer config file'
       type: 'boolean'
       default: false
-      description: 'Run only if a `.php_cs` config file is available'
+      description: 'Run only if a `.php_cs` or `.php-cs-fixer.php` config file is available'
       order: 26
     executeOnSave:
       title: 'Execute on save'
@@ -140,7 +140,7 @@ module.exports = PhpCsFixer =
 
     args = args.concat [@executablePath, 'fix', filePath]
 
-    if not @configPath and configPath = @findFile(path.dirname(filePath.toString()), ['.php_cs', '.php_cs.dist'])
+    if not @configPath and configPath = @findFile(path.dirname(filePath.toString()), ['.php_cs', '.php_cs.dist', '.php-cs-fixer.php', '.php-cs-fixer.dist.php'])
       @configPath = configPath
       console.log(configPath);
 


### PR DESCRIPTION
There are a handful of [breaking changes](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/UPGRADE-v3.md) in the new version of PHP-CS-Fixer. This PR allows for the detection of the new configuration file name, as well as updating the example configuration file.